### PR TITLE
[unfeature] `repos` parameter

### DIFF
--- a/src/utils/piplineRun.ts
+++ b/src/utils/piplineRun.ts
@@ -64,10 +64,6 @@ export class PipelineRun {
 							value: `${this._deployment.deploymentName}`
 						},
 						{
-							name: 'repos',
-							value: [pr.repository()]
-						},
-						{
 							name: 'branch-name',
 							value: pr.branchName()
 						},


### PR DESCRIPTION
As of https://github.com/epfl-si/wp-ops/pull/691, this parameter is unused.