### PR TITLE
[fix] Catch GitHub API failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,21 +57,21 @@ async function scheduleActivePRsToDeployments(config: Config) {
 		{
 			onDeploySuccess(prs: PullRequestInfo[]) {
 				for ( const pr of prs ) {
-					notificationWork.push(pr.createComment(getCallSignOfDeployment(dep) + pr.success(getBuildUrlOfDeployment(dep))));
+					notificationWork.push(pr.tryCreateComment(getCallSignOfDeployment(dep) + pr.success(getBuildUrlOfDeployment(dep))));
 				}
 				notificationWork.push(notifyEvictions(openPullRequests, getBuildUrlOfDeployment(dep), dep.builtFromBranch));
 			},
 			onDeployFailure(prs: PullRequestInfo[], err: Error) {
 				error(`Failed to schedule to deployment ${dep.deploymentName}: ${getErrorMessage(err)}`, err)
 				for ( const pr of prs ) {
-					notificationWork.push(pr.createComment(getCallSignOfDeployment(dep) + pr.fail(err)));
+					notificationWork.push(pr.tryCreateComment(getCallSignOfDeployment(dep) + pr.fail(err)));
 				}
 			}
 		}
 	)));
 	for (const branchName of Object.keys(activePullRequestGroups)) {
 		for (const pr of activePullRequestGroups[branchName]) {
-			notificationWork.push(pr.createComment('🍍 ' + pr.skipped()))
+			notificationWork.push(pr.tryCreateComment('🍍 ' + pr.skipped()))
 		}
 	}
 
@@ -162,7 +162,7 @@ async function notifyEvictions(openPullRequests: {pullRequest: PullRequestInfo,	
 		p.branchName() != deploymentBranchName
 	)
 	for ( const epr of evictedPullRequests ) {
-		await epr.createComment('🍍' + epr.expired());
+		await epr.tryCreateComment('🍍' + epr.expired());
 	}
 }
 

--- a/src/lib/pullRequestInfo.ts
+++ b/src/lib/pullRequestInfo.ts
@@ -110,8 +110,12 @@ ${reason}
 			new Date(current.updated_at) > new Date(latest.updated_at) ? current : latest);
 	}
 
-	async createComment(message: string){
-		await callGitHubAPI(this._config, `/repos/epfl-si/${this._repository}/issues/${this._number}/comments`, 'POST', undefined, {body: message});
+	async tryCreateComment(message: string) {
+		try {
+			await callGitHubAPI(this._config, `/repos/epfl-si/${this._repository}/issues/${this._number}/comments`, 'POST', undefined, {body: message});
+		} catch (e) {
+			console.error("Unable to comment in review thread: ", e);
+		}
 	}
 
 	static async getPullRequests(config: Config) {


### PR DESCRIPTION
This happens when the bot tries to comment in a repo it doesn't have write access  to. (In that case one must add the repo to https://github.com/organizations/epfl-si/settings/installations/70642946 while wielding epfl-si org admin permissions.)

We want an error in the logs, rather than a crashloop as the latter causes an endless stream of pipeline rebuilds.